### PR TITLE
Update to swift 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.3
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Add the following header to your swift source code:
 ``` swift
 import PerfectPCRE2
 ```
+For swift tools 5.3, it also seems that you need to add the libpcre2-8 library to Frameworks and Libraries, probably from something like "/usr/local/Cellar/pcre2/10.36/lib", and make sure it's set to Embed and Sign. 
 
 ### Simple Usage
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 
 This project provides an easy solution to extract captured groups from a string by a PCRE2 compatible regular expression.
 
+This repo is a fork from the original and probably ought not be trusted at the moment.
+
 This package builds with Swift Package Manager and is part of the [Perfect](https://github.com/PerfectlySoft/Perfect) project but can also be used as an independent module.
 
 ## Quick Start
@@ -51,7 +53,7 @@ This package builds with Swift Package Manager and is part of the [Perfect](http
 
 #### Swift Version
 
-Swift 4.2+
+Swift 5.3+
 
 #### macOS
 
@@ -70,8 +72,8 @@ $ sudo apt-get install libpcre2-dev
 Add dependencies to your Package.swift
 
 ``` swift
-.package(url: "https://github.com/RockfordWei/Perfect-PCRE2.git", 
-	from: "3.1.0")
+.package(url: "https://github.com/MrTheSaw/Perfect-PCRE2.git", 
+	from: "3.1.1")
 
 // on target section:
 .target(

--- a/README.md
+++ b/README.md
@@ -1,44 +1,5 @@
 # Perfect-PCRE2
 
-<p align="center">
-    <a href="http://perfect.org/get-involved.html" target="_blank">
-        <img src="http://perfect.org/assets/github/perfect_github_2_0_0.jpg" alt="Get Involed with Perfect!" width="854" />
-    </a>
-</p>
-
-<p align="center">
-    <a href="https://github.com/PerfectlySoft/Perfect" target="_blank">
-        <img src="http://www.perfect.org/github/Perfect_GH_button_1_Star.jpg" alt="Star Perfect On Github" />
-    </a>  
-    <a href="http://stackoverflow.com/questions/tagged/perfect" target="_blank">
-        <img src="http://www.perfect.org/github/perfect_gh_button_2_SO.jpg" alt="Stack Overflow" />
-    </a>  
-    <a href="https://twitter.com/perfectlysoft" target="_blank">
-        <img src="http://www.perfect.org/github/Perfect_GH_button_3_twit.jpg" alt="Follow Perfect on Twitter" />
-    </a>  
-    <a href="http://perfect.ly" target="_blank">
-        <img src="http://www.perfect.org/github/Perfect_GH_button_4_slack.jpg" alt="Join the Perfect Slack" />
-    </a>
-</p>
-
-<p align="center">
-    <a href="https://developer.apple.com/swift/" target="_blank">
-        <img src="https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat" alt="Swift 4.2">
-    </a>
-    <a href="https://developer.apple.com/swift/" target="_blank">
-        <img src="https://img.shields.io/badge/Platforms-OS%20X%20%7C%20Linux%20-lightgray.svg?style=flat" alt="Platforms OS X | Linux">
-    </a>
-    <a href="http://perfect.org/licensing.html" target="_blank">
-        <img src="https://img.shields.io/badge/License-Apache-lightgrey.svg?style=flat" alt="License Apache">
-    </a>
-    <a href="http://twitter.com/PerfectlySoft" target="_blank">
-        <img src="https://img.shields.io/badge/Twitter-@PerfectlySoft-blue.svg?style=flat" alt="PerfectlySoft Twitter">
-    </a>
-    <a href="http://perfect.ly" target="_blank">
-        <img src="http://perfect.ly/badge.svg" alt="Slack Status">
-    </a>
-</p>
-
 
 
 This project provides an easy solution to extract captured groups from a string by a PCRE2 compatible regular expression.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,47 @@
 # Perfect-PCRE2
 
+<p align="center">
+    <a href="http://perfect.org/get-involved.html" target="_blank">
+        <img src="http://perfect.org/assets/github/perfect_github_2_0_0.jpg" alt="Get Involed with Perfect!" width="854" />
+    </a>
+</p>
+
+<p align="center">
+    <a href="https://github.com/PerfectlySoft/Perfect" target="_blank">
+        <img src="http://www.perfect.org/github/Perfect_GH_button_1_Star.jpg" alt="Star Perfect On Github" />
+    </a>  
+    <a href="http://stackoverflow.com/questions/tagged/perfect" target="_blank">
+        <img src="http://www.perfect.org/github/perfect_gh_button_2_SO.jpg" alt="Stack Overflow" />
+    </a>  
+    <a href="https://twitter.com/perfectlysoft" target="_blank">
+        <img src="http://www.perfect.org/github/Perfect_GH_button_3_twit.jpg" alt="Follow Perfect on Twitter" />
+    </a>  
+    <a href="http://perfect.ly" target="_blank">
+        <img src="http://www.perfect.org/github/Perfect_GH_button_4_slack.jpg" alt="Join the Perfect Slack" />
+    </a>
+</p>
+
+<p align="center">
+    <a href="https://developer.apple.com/swift/" target="_blank">
+        <img src="https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat" alt="Swift 4.2">
+    </a>
+    <a href="https://developer.apple.com/swift/" target="_blank">
+        <img src="https://img.shields.io/badge/Platforms-OS%20X%20%7C%20Linux%20-lightgray.svg?style=flat" alt="Platforms OS X | Linux">
+    </a>
+    <a href="http://perfect.org/licensing.html" target="_blank">
+        <img src="https://img.shields.io/badge/License-Apache-lightgrey.svg?style=flat" alt="License Apache">
+    </a>
+    <a href="http://twitter.com/PerfectlySoft" target="_blank">
+        <img src="https://img.shields.io/badge/Twitter-@PerfectlySoft-blue.svg?style=flat" alt="PerfectlySoft Twitter">
+    </a>
+    <a href="http://perfect.ly" target="_blank">
+        <img src="http://perfect.ly/badge.svg" alt="Slack Status">
+    </a>
+</p>
+
 
 
 This project provides an easy solution to extract captured groups from a string by a PCRE2 compatible regular expression.
-
-This repo is a fork from the original and probably ought not be trusted at the moment.
 
 This package builds with Swift Package Manager and is part of the [Perfect](https://github.com/PerfectlySoft/Perfect) project but can also be used as an independent module.
 
@@ -14,7 +51,7 @@ This package builds with Swift Package Manager and is part of the [Perfect](http
 
 #### Swift Version
 
-Swift 5.3+
+Swift 4.2+
 
 #### macOS
 
@@ -33,8 +70,8 @@ $ sudo apt-get install libpcre2-dev
 Add dependencies to your Package.swift
 
 ``` swift
-.package(url: "https://github.com/MrTheSaw/Perfect-PCRE2.git", 
-	from: "3.1.1")
+.package(url: "https://github.com/RockfordWei/Perfect-PCRE2.git", 
+	from: "3.1.0")
 
 // on target section:
 .target(
@@ -49,7 +86,6 @@ Add the following header to your swift source code:
 ``` swift
 import PerfectPCRE2
 ```
-For swift tools 5.3, it also seems that you need to add the libpcre2-8 library to Frameworks and Libraries, probably from something like "/usr/local/Cellar/pcre2/10.36/lib", and make sure it's set to Embed and Sign. 
 
 ### Simple Usage
 

--- a/Sources/PerfectPCRE2/PerfectPCRE2.swift
+++ b/Sources/PerfectPCRE2/PerfectPCRE2.swift
@@ -222,8 +222,8 @@ public class PCRE2 {
       }
       let array = Array(UnsafeBufferPointer<Int>(start: ovector, count: Int(rc) * 2))
       for i in 0..<Int(rc) {
-        let start = String.Index(encodedOffset: array[i * 2])
-        let end = String.Index(encodedOffset: array[i * 2 + 1])
+        let start = String.Index(utf16Offset: array[i * 2], in: subject)
+        let end = String.Index(utf16Offset: array[i * 2 + 1], in: subject)
         offset = array[i * 2 + 1] + 1
         range.append(start..<end)
       }
@@ -253,7 +253,7 @@ public extension String {
   /// - parameter optionsOfMatch: the options to apply in the pattern match
   /// - returns: array of matched substrings
   /// - throws: Exception
-  public func pcre2Match(pattern: String, optionsOfPattern: [PCRE2.OptionPattern] = [.UTF], optionsOfMatch: [PCRE2.OptionMatch] = []) throws -> [[String]] {
+  func pcre2Match(pattern: String, optionsOfPattern: [PCRE2.OptionPattern] = [.UTF], optionsOfMatch: [PCRE2.OptionMatch] = []) throws -> [[String]] {
     let re = try PCRE2(pattern: pattern, options: optionsOfPattern)
     let ranges = try re.match(self, options: optionsOfMatch)
     return ranges.map { $0.map { String(self[$0]) } }


### PR DESCRIPTION
A minor bit of work to get rid of compiler warnings.

I needed to add libpcre2_8.dylib to the Frameworks and Libraries panel to make it work in Xcode 12.5. I don't understand how that stuff works well enough yet, maybe there is a better way?